### PR TITLE
Make connection the last argument in `perform_(now|later)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Changed
 
-N/A
+- Functions that previously took the connection in the first place, and job arguments in the second place now take the connection in the last place. That was mainly `perform_now` and `perform_later`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 - `Config` has gotten a `redis_url` field. That URL will be used when connecting to Redis in workers and clients. Defaults to `redis://127.0.0.1/`.
 - `perform_now` has been added back. It can be called on anything that also has `perform_later`, but will block and perform the job right now.
+- Make the `perform_with` attribute on `#[derive(Job)]` optional. Will default to a function called `perform_my_job` if the enum variant is `MyJob`.
 
 ### Changed
 
-- Make the `perform_with` attribute on `#[derive(Job)]` optional. Will default to a function called `perform_my_job` if the enum variant is `MyJob`.
+N/A
 
 ### Deprecated
 

--- a/robin-derives/src/jobs.rs
+++ b/robin-derives/src/jobs.rs
@@ -85,7 +85,7 @@ fn job_impl(name: &Ident, enum_data: &DataEnum) -> Tokens {
             };
 
             quote! {
-                #qualified_name => { #perform_with(con, args.deserialize()?) }
+                #qualified_name => { #perform_with(args.deserialize()?, con) }
             }
         })
         .collect::<Vec<_>>();
@@ -98,7 +98,7 @@ fn job_impl(name: &Ident, enum_data: &DataEnum) -> Tokens {
                 }
             }
 
-            fn perform(&self, con: &WorkerConnection, args: &Args) -> JobResult {
+            fn perform(&self, args: &Args, con: &WorkerConnection) -> JobResult {
                 match *self {
                     #(#job_perform_match_arms),*
                 }

--- a/robin/examples/client_and_worker.rs
+++ b/robin/examples/client_and_worker.rs
@@ -29,7 +29,7 @@ fn client(config: Config) {
 
     for i in 0..n {
         println!("{}/{}", i + 1, n);
-        Jobs::MyJob.perform_later(&con, &JobArgs).unwrap();
+        Jobs::MyJob.perform_later(&JobArgs, &con).unwrap();
     }
 }
 
@@ -42,7 +42,7 @@ enum Jobs {
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct JobArgs;
 
-fn perform_my_job(_con: &WorkerConnection, args: JobArgs) -> JobResult {
+fn perform_my_job(args: JobArgs, _con: &WorkerConnection) -> JobResult {
     println!("Job performed with {:?}", args);
     Ok(())
 }

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -36,7 +36,7 @@
 //! #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 //! pub struct JobArgs;
 //!
-//! fn perform_my_job(_con: &WorkerConnection, args: JobArgs) -> JobResult {
+//! fn perform_my_job(args: JobArgs, _con: &WorkerConnection) -> JobResult {
 //!     println!("Job performed with {:?}", args);
 //!     Ok(())
 //! }
@@ -57,7 +57,7 @@
 //! assert_eq!(con.retry_queue_size()?, 0);
 //!
 //! for i in 0..5 {
-//!     Jobs::MyJob.perform_later(&con, &JobArgs)?;
+//!     Jobs::MyJob.perform_later(&JobArgs, &con)?;
 //! }
 //!
 //! assert_eq!(con.main_queue_size()?, 5);

--- a/robin/src/worker/mod.rs
+++ b/robin/src/worker/mod.rs
@@ -147,7 +147,7 @@ fn perform_or_retry(
     worker_number: WorkerNumber,
 ) {
     let args = serde_json::from_str(args).expect("todo");
-    let job_result = job.perform(&con, &args);
+    let job_result = job.perform(&args, &con);
 
     match job_result {
         Ok(()) => println!(

--- a/robin/tests/test_helper/mod.rs
+++ b/robin/tests/test_helper/mod.rs
@@ -71,12 +71,12 @@ impl Jobs {
     }
 }
 
-fn perform_verifyable_job(_con: &WorkerConnection, args: VerifyableJobArgs) -> JobResult {
+fn perform_verifyable_job(args: VerifyableJobArgs, _con: &WorkerConnection) -> JobResult {
     write_tmp_test_file(args.file, args.file);
     Ok(())
 }
 
-fn perform_pass_second_time(_con: &WorkerConnection, args: PassSecondTimeArgs) -> JobResult {
+fn perform_pass_second_time(args: PassSecondTimeArgs, _con: &WorkerConnection) -> JobResult {
     let contents = args.file().map(|file| read_tmp_test_file(file));
 
     match contents {
@@ -100,7 +100,7 @@ fn perform_pass_second_time(_con: &WorkerConnection, args: PassSecondTimeArgs) -
     }
 }
 
-fn perform_fail_forever(_con: &WorkerConnection, _args: FailForeverArgs) -> JobResult {
+fn perform_fail_forever(_args: FailForeverArgs, _con: &WorkerConnection) -> JobResult {
     Err("Will always fail".to_string())
 }
 


### PR DESCRIPTION
I don't think this matter a whole lot, but I do think this is way is
slightly nicer for the user.

Fixes https://github.com/davidpdrsn/robin/issues/36