### PR TITLE
Change error type in `JobResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 ### Changed
 
 - Functions that previously took the connection in the first place, and job arguments in the second place now take the connection in the last place. That was mainly `perform_now` and `perform_later`.
+- The error type in `JobResult` has been changed from `String` to `Box<std::error::Error>`. Allows clients to keep using their own error types without having to map errors to strings all the time.
 
 ### Deprecated
 

--- a/robin/tests/performing_jobs_test.rs
+++ b/robin/tests/performing_jobs_test.rs
@@ -144,8 +144,8 @@ fn jobs_with_unit_as_args() {
         JobWithoutArgs,
     }
 
-    fn perform_my_job(args: (), _con: &WorkerConnection) -> JobResult {
-        Err("it worked".to_string())
+    fn perform_my_job(_args: (), _con: &WorkerConnection) -> JobResult {
+        TestError::with_msg("it worked")
     }
 
     let con = establish(Config::default(), Jobs::lookup_job).expect("Failed to connect");
@@ -153,7 +153,7 @@ fn jobs_with_unit_as_args() {
     let result = Jobs::JobWithoutArgs.perform_now(&(), &con);
 
     match result {
-        Err(Error::JobFailed(msg)) => assert_eq!(msg, "it worked".to_string()),
+        Err(Error::JobFailed(msg)) => assert_eq!(msg.description(), "it worked".to_string()),
         _ => panic!("no match"),
     }
 }


### PR DESCRIPTION
It is more flexible to return `Box<std::error::Error>`. Was previously just `String`.
This way users can stick to using whatever error type they want.

Fixes https://github.com/davidpdrsn/robin/issues/34