### PR TITLE
Print jobs/sec from the worker

### DIFF
--- a/robin/examples/client_and_worker.rs
+++ b/robin/examples/client_and_worker.rs
@@ -25,7 +25,7 @@ fn worker(config: Config) {
 fn client(config: Config) {
     let con = establish(config, Jobs::lookup_job).expect("Failed to connect");
 
-    let n = 100;
+    let n = 10;
 
     for i in 0..n {
         println!("{}/{}", i + 1, n);

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -1,6 +1,6 @@
-#![deny(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+#![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
+        trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
+        unused_import_braces, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/robin/0.2.0")]
 
 //! # Robin
@@ -108,6 +108,8 @@ pub mod worker;
 
 /// Contains the config type used to configure Robin.
 pub mod config;
+
+mod ticker;
 
 pub mod prelude {
     //! Reexports the most commonly used types and traits from the other modules.

--- a/robin/src/ticker.rs
+++ b/robin/src/ticker.rs
@@ -1,0 +1,54 @@
+use std::{sync::Mutex, time::{Duration, Instant}};
+
+pub struct Ticker {
+    ticks: Mutex<u32>,
+    start: Mutex<Instant>,
+}
+
+impl Ticker {
+    pub fn new() -> Self {
+        Ticker {
+            ticks: Mutex::new(0),
+            start: Mutex::new(Instant::now()),
+        }
+    }
+
+    pub fn tick(&self) {
+        let mut count = self.ticks.lock().unwrap();
+        *count += 1;
+    }
+
+    pub fn ticks_per_second(&self) -> f64 {
+        self.ticks() as f64 / duration_to_f64(self.elapsed())
+    }
+
+    fn ticks(&self) -> u32 {
+        *self.ticks.lock().unwrap()
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.start.lock().unwrap().elapsed()
+    }
+
+    pub fn reset(&self) {
+        let mut ticks = self.ticks.lock().unwrap();
+        *ticks = 0;
+
+        let mut start = self.start.lock().unwrap();
+        *start = Instant::now();
+    }
+}
+
+// Copied from ggez source
+pub fn duration_to_f64(d: Duration) -> f64 {
+    let seconds = d.as_secs() as f64;
+    let nanos = f64::from(d.subsec_nanos());
+    seconds + (nanos * 1e-9)
+}
+
+#[cfg(test)]
+#[allow(warnings)]
+fn timer_impls_send_and_sync() {
+    let ticker: Ticker = unimplemented!();
+    let x: &(Send + Sync) = &ticker;
+}


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/robin/issues/31

The goal of this change is to be able to measure number of jobs per second Robin is able to do.

This works by incrementing a counter every time a job is run, and printing number of increments every 5 seconds. Every 10 seconds the counter will be reset.

I have benched this locally and gotten 11k jobs/sec. That seems reasonable since sidekiq mentions getting 4500 on [their github page](https://github.com/mperham/sidekiq).

Now I just need to wrap this into some kind of benchmark script that we can run periodically to look for performance regressions.