### PR TITLE
Clean up API with three new macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
-N/A
+- `jobs!` macro which removes all boilerplate around defining jobs.
+- `robin_establish_connection!` macro which makes it simpler to open a new connection without needing to know about `LookupJob`.
+- `robin_boot_worker!` macro which makes it simpler to boot the worker without needing to know about `LookupJob`.
+- While the worker is running it will now print jobs/second
 
 ### Changed
 
-N/A
+- `Config.worker_count` will now default to number of CPUs.
 
 ### Deprecated
 

--- a/robin/src/config.rs
+++ b/robin/src/config.rs
@@ -3,7 +3,7 @@ use num_cpus;
 
 /// Configuration options used throughout Robin.
 ///
-/// The normal way to construct a `Config` is the `Default` implementation.
+/// The normal way to construct a `Config` is through the `Default` implementation.
 /// Afterwards you can tweak the values you need.
 ///
 /// ```rust

--- a/robin/src/connection/mod.rs
+++ b/robin/src/connection/mod.rs
@@ -113,8 +113,11 @@ impl WorkerConnection {
 
 /// Create a new connection.
 ///
+/// **NOTE:** You normally wouldn't need to call this. Instead use the
+/// `robin_establish_connection!` macro in the `macros` module.
+///
 /// The lookup function is necessary for parsing the `String` we get from Redis
-/// into a Rust type.
+/// into a job type.
 ///
 /// Make sure the config you're using here is the same config you use to boot the worker in
 /// `worker::boot`.
@@ -129,7 +132,7 @@ pub fn establish<T: 'static + LookupJob>(
     })
 }
 
-/// Trait that maps a `String` given to Robin by Redis to an actual Rust type.
+/// Trait that maps a `String` given to Robin by Redis to an actual job type.
 pub trait LookupJob {
     /// Perform the lookup.
     fn lookup(&self, name: &JobName) -> Option<Box<Job + Send>>;

--- a/robin/src/job/mod.rs
+++ b/robin/src/job/mod.rs
@@ -30,7 +30,7 @@ impl Args {
     /// Generic function for deserializing the encoded arguments into the type
     /// required by the job.
     ///
-    /// Will return `Err(Error::JobFailed(_))` if deserialization fails.
+    /// Will return `Err(Error::SerdeJsonError(_))` if deserialization fails.
     /// This will most likely happen if a given job doesn't support the arguments type you're
     /// trying to deserialize into.
     pub fn deserialize<'a, T: Deserialize<'a>>(&'a self) -> RobinResult<T> {
@@ -41,7 +41,7 @@ impl Args {
     }
 }
 
-/// The trait that defines what a particular job should do.
+/// The trait that defines what a particular job should does.
 pub trait Job {
     /// The name of the job. Required to put the job into Redis.
     fn name(&self) -> JobName;

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -5,17 +5,21 @@
 
 //! # Robin
 //!
-//! Robin lets you run jobs in the background. This could be payment processing or sending emails.
-//! Inspired by ActiveJob from Ruby on Rails.
+//! Robin lets you run jobs in the background. This could for example be payment processing or
+//! sending emails.
+//!
+//! If you've used ActiveJob from Ruby on Rails you'll feel right at home.
 //!
 //! ## Getting started
 //!
-//! The standard way to use Robin is through the `#[derive(Job)]` macro. It works on
-//! enum and will generate all the boilerplate needed to perform jobs.
+//! The standard way to use Robin is through the `jobs!` macro. It takes a comma separated list of
+//! job names, and generates all the boilerplate for you. Just you have to define a static method
+//! named `perform` on each of your jobs.
 //!
 //! Here is a full example:
 //!
 //! ```rust
+//! #[macro_use]
 //! extern crate robin;
 //! #[macro_use]
 //! extern crate serde_derive;
@@ -27,19 +31,19 @@
 //! # fn try_main() -> Result<(), Box<Error>> {
 //! use robin::prelude::*;
 //!
-//! #[derive(Job)]
-//! enum Jobs {
-//!     #[perform_with(perform_my_job)]
+//! jobs! {
 //!     MyJob,
 //! }
 //!
-//! #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
-//! pub struct JobArgs;
-//!
-//! fn perform_my_job(args: JobArgs, _con: &WorkerConnection) -> JobResult {
-//!     println!("Job performed with {:?}", args);
-//!     Ok(())
+//! impl MyJob {
+//!     fn perform(args: JobArgs, _con: &WorkerConnection) -> JobResult {
+//!         println!("Job performed with {:?}", args);
+//!         Ok(())
+//!     }
 //! }
+//!
+//! #[derive(Serialize, Deserialize, Debug)]
+//! pub struct JobArgs;
 //!
 //! let config = Config::default();
 //! # let mut config = Config::default();
@@ -48,22 +52,21 @@
 //! # config.repeat_on_timeout = false;
 //! # config.retry_count_limit = 1;
 //! # config.worker_count = 1;
-//! let worker_config = config.clone();
 //!
-//! let con = robin::connection::establish(config, Jobs::lookup_job)?;
+//! let con = robin_establish_connection!(config)?;
 //! # con.delete_all();
 //!
 //! assert_eq!(con.main_queue_size()?, 0);
 //! assert_eq!(con.retry_queue_size()?, 0);
 //!
 //! for i in 0..5 {
-//!     Jobs::MyJob.perform_later(&JobArgs, &con)?;
+//!     MyJob::perform_later(&JobArgs, &con)?;
 //! }
 //!
 //! assert_eq!(con.main_queue_size()?, 5);
 //! assert_eq!(con.retry_queue_size()?, 0);
 //!
-//! robin::worker::boot(&worker_config, Jobs::lookup_job);
+//! robin_boot_worker!(config);
 //!
 //! assert_eq!(con.main_queue_size()?, 0);
 //! assert_eq!(con.retry_queue_size()?, 0);
@@ -71,13 +74,15 @@
 //! # }
 //! ```
 //!
-//! Normally the code the enqueues jobs and the code the boots the worker would be in separate
+//! Normally the code that enqueues jobs and the code the boots the worker would be in separate
 //! binaries.
+//!
+//! For more details see the `robin::macros` module documentation.
 //!
 //! ## The prelude
 //!
 //! Robin provides a prelude module which exports all the commonly used types and traits.
-//! Code using Robin is expected to have
+//! Code using Robin is expected to have:
 //!
 //! ```rust
 //! use robin::prelude::*;
@@ -110,16 +115,149 @@ pub mod worker;
 /// Contains the config type used to configure Robin.
 pub mod config;
 
+/// Contains the macros exported by Robin.
+///
+/// # `jobs!`
+///
+/// Takes a comma separate list of struct names. Each struct will become a job that you can call
+/// `perform_now` or `perform_later` on. You just have to implement a static method named `perform`
+/// on each struct that does the actual work.
+///
+/// ## Example
+///
+/// ```rust
+/// #[macro_use]
+/// extern crate robin;
+/// #[macro_use]
+/// extern crate serde_derive;
+/// #
+/// use robin::prelude::*;
+///
+/// # fn main() {
+/// jobs! {
+///     SendPushNotification,
+/// }
+///
+/// impl SendPushNotification {
+///     fn perform(args: SendPushNotificationArgs, _con: &WorkerConnection) -> JobResult {
+///         // Code for actually sending push notifications
+///         Ok(())
+///     }
+/// }
+///
+/// #[derive(Serialize, Deserialize, Debug)]
+/// pub struct SendPushNotificationArgs {
+///     device_id: String,
+///     platform: DevicePlatform,
+/// }
+///
+/// #[derive(Serialize, Deserialize, Debug)]
+/// pub enum DevicePlatform {
+///     Ios,
+///     Android,
+/// }
+/// # }
+/// ```
+///
+/// # `robin_establish_connection!`
+///
+/// Creates a new connection used to enqueued jobs, using the given config.
+///
+/// ## Example
+///
+/// ```rust
+/// #[macro_use]
+/// extern crate robin;
+/// #[macro_use]
+/// extern crate serde_derive;
+///
+/// use robin::prelude::*;
+///
+/// # use std::error::Error;
+/// # fn main() { try_main().unwrap() }
+/// # fn try_main() -> Result<(), Box<Error>> {
+/// # jobs! {
+/// #     SendPushNotification,
+/// # }
+/// #
+/// # impl SendPushNotification {
+/// #     fn perform(args: SendPushNotificationArgs, _con: &WorkerConnection) -> JobResult {
+/// #         Ok(())
+/// #     }
+/// # }
+/// #
+/// # #[derive(Serialize, Deserialize, Debug)]
+/// # pub struct SendPushNotificationArgs {
+/// #     device_id: String,
+/// #     platform: DevicePlatform,
+/// # }
+/// #
+/// # #[derive(Serialize, Deserialize, Debug)]
+/// # pub enum DevicePlatform {
+/// #     Ios,
+/// #     Android,
+/// # }
+/// let config = Config::default();
+///
+/// let con = robin_establish_connection!(config)?;
+///
+/// let args = SendPushNotificationArgs {
+///     device_id: "123".to_string(),
+///     platform: DevicePlatform::Android,
+/// };
+///
+/// SendPushNotification::perform_later(&args, &con)?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # `robin_boot_worker!`
+///
+/// Boots the worker which performs the jobs.
+///
+/// ## Example
+/// ```rust
+/// #[macro_use]
+/// extern crate robin;
+/// #[macro_use]
+/// extern crate serde_derive;
+///
+/// use robin::prelude::*;
+///
+/// # fn main() {
+/// # jobs! {
+/// #     MyJob,
+/// # }
+/// # impl MyJob {
+/// #     fn perform(args: (), _con: &WorkerConnection) -> JobResult {
+/// #         Ok(())
+/// #     }
+/// # }
+/// let config = Config::default();
+/// # let mut config = Config::default();
+/// # config.timeout = 1;
+/// # config.redis_namespace = "doc_tests_for_boot_worker_macro".to_string();
+/// # config.repeat_on_timeout = false;
+/// # config.retry_count_limit = 1;
+/// # config.worker_count = 1;
+///
+/// robin_boot_worker!(config);
+/// # }
+/// ```
+pub mod macros;
+
 mod ticker;
 
 pub mod prelude {
     //! Reexports the most commonly used types and traits from the other modules.
     //! As long as you're doing standard things this is the only `use` you'll need.
 
+    pub use serde::Serialize;
     pub use job::{Args, Job, JobName, JobResult, PerformJob};
     pub use error::RobinResult;
     pub use connection::{establish, LookupJob, WorkerConnection};
     pub use worker::boot;
     pub use config::Config;
     pub use robin_derives::*;
+    pub use macros::*;
 }

--- a/robin/src/macros.rs
+++ b/robin/src/macros.rs
@@ -1,0 +1,63 @@
+#[macro_export]
+macro_rules! jobs {
+    (
+        $($id:ident,)*
+    ) => {
+        #[derive(Job)]
+        enum __RobinJobs {
+            $(
+                $id,
+            )*
+        }
+
+        $(
+            pub struct $id;
+
+            impl Job for $id {
+                #[inline]
+                fn name(&self) -> JobName {
+                    __RobinJobs::$id.name()
+                }
+
+                #[inline]
+                fn perform(&self, args: &Args, con: &WorkerConnection) -> JobResult {
+                    __RobinJobs::$id.perform(args, con)
+                }
+            }
+
+            impl $id {
+                #[allow(dead_code)]
+                #[inline]
+                pub fn perform_now<A: Serialize>(
+                    args: A,
+                    con: &WorkerConnection,
+                ) -> RobinResult<()> {
+                    $id.perform_now(args, con)
+                }
+
+                #[allow(dead_code)]
+                #[inline]
+                pub fn perform_later<A: Serialize>(
+                    args: A,
+                    con: &WorkerConnection,
+                ) -> RobinResult<()> {
+                    $id.perform_later(args, con)
+                }
+            }
+        )*
+    }
+}
+
+#[macro_export]
+macro_rules! robin_establish_connection {
+    ($config:expr) => (
+        robin::connection::establish($config.clone(), jobs::lookup_job)
+    )
+}
+
+#[macro_export]
+macro_rules! robin_boot_worker {
+    ($config:expr) => (
+        robin::worker::boot(&$config.clone(), jobs::lookup_job);
+    )
+}

--- a/robin/src/worker/mod.rs
+++ b/robin/src/worker/mod.rs
@@ -10,11 +10,17 @@ use serde_json;
 
 /// Boot the worker.
 ///
+/// **NOTE:** You normally wouldn't need to call this. Instead use the
+/// `robin_boot_worker!` macro in the `macros` module.
+///
 /// This will spawn the numbers of threads set by `config.worker_count`. Each thread
-/// will dequeue a job, perform, and repeat.
+/// will dequeue a job, perform it, and repeat.
 ///
 /// Make sure the config you're using here is the same config you use to establish the connection
-/// in `connection::establish`.
+/// in `robin_establish_connection!`.
+///
+/// This will also print some metrics every few seconds. The output look like "Robin worker metric: Jobs per second 11000".
+/// ```
 pub fn boot<T>(config: &Config, lookup_job: T)
 where
     T: 'static,

--- a/robin/tests/performing_jobs_test.rs
+++ b/robin/tests/performing_jobs_test.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate robin;
 #[macro_use]
 extern crate serde_derive;
@@ -138,19 +139,19 @@ fn job_doesnt_get_retried_forever() {
 fn jobs_with_unit_as_args() {
     use robin::error::Error;
 
-    #[derive(Job)]
-    enum Jobs {
-        #[perform_with(perform_my_job)]
+    jobs! {
         JobWithoutArgs,
     }
 
-    fn perform_my_job(_args: (), _con: &WorkerConnection) -> JobResult {
-        TestError::with_msg("it worked")
+    impl JobWithoutArgs {
+        fn perform(_args: (), _con: &WorkerConnection) -> JobResult {
+            TestError::with_msg("it worked")
+        }
     }
 
-    let con = establish(Config::default(), Jobs::lookup_job).expect("Failed to connect");
+    let con = establish(Config::default(), jobs::lookup_job).expect("Failed to connect");
 
-    let result = Jobs::JobWithoutArgs.perform_now(&(), &con);
+    let result = JobWithoutArgs::perform_now(&(), &con);
 
     match result {
         Err(Error::JobFailed(msg)) => assert_eq!(msg.description(), "it worked".to_string()),

--- a/robin/tests/test_helper/mod.rs
+++ b/robin/tests/test_helper/mod.rs
@@ -22,7 +22,7 @@ impl TestHelper {
     pub fn setup<T: WithTempFile>(&self, args: &T) {
         fs::create_dir("tests/tmp").ok();
 
-        let con = establish(Config::test_config(&self.uuid), Jobs::lookup_job)
+        let con = establish(Config::test_config(&self.uuid), jobs::lookup_job)
             .expect("Failed to connect");
 
         con.delete_all().unwrap();
@@ -41,14 +41,14 @@ impl TestHelper {
         let uuid = self.uuid.clone();
         thread::spawn(move || {
             let con =
-                establish(Config::test_config(&uuid), Jobs::lookup_job).expect("Failed to connect");
+                establish(Config::test_config(&uuid), jobs::lookup_job).expect("Failed to connect");
             f(con)
         })
     }
 
     pub fn spawn_worker(&mut self) -> JoinHandle<()> {
         let uuid = self.uuid.clone();
-        thread::spawn(move || boot(&Config::test_config(&uuid), Jobs::lookup_job))
+        thread::spawn(move || boot(&Config::test_config(&uuid), jobs::lookup_job))
     }
 }
 
@@ -62,6 +62,7 @@ pub enum Jobs {
     VerifyableJob,
     #[perform_with(perform_pass_second_time)]
     PassSecondTime,
+    #[perform_with(perform_fail_forever)]
     FailForever,
 }
 


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/robin/issues/35

Adds the following new macros:

- `jobs!`: Will generate the `Jobs` enum and add `#[derive(Job)]`. Will also generate some structs that mean you never need to know about the `Jobs` enum.
- `robin_boot_worker!(config)`: Simply expands to `robin::worker::boot(&config, jobs::lookup_job)`. This is just so the users don't need to know about `jobs::lookup_job`. This function is generated by deriving `Job` which is a bit magical.
- `robin_establish_connection!(config)`: Same as the macro for booting the worker, but for creating the connection used to enqueue jobs.

With these changes the new API is this:

```rust
#[macro_use]
extern crate robin;
#[macro_use]
extern crate serde_derive;
use robin::prelude::*;

jobs! {
    MyJob,
}

impl MyJob {
    fn perform(args: JobArgs, _con: &WorkerConnection) -> JobResult {
        println!("Job performed with {:?}", args);
        Ok(())
    }
}

#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
pub struct JobArgs;

let config = Config::default();
let con = robin_establish_connection!(config)?;
robin_boot_worker!(worker_config);

MyJob::perform_later(&JobArgs, &con)?;
```

I am very happy with this API. To me it is basically what I'd expect coming to Rust after having used active job from Rails.