### PR TITLE
Make `SomeJob::perform_(later|now)` type safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ N/A
 
 ### Changed
 
-N/A
+- Remove `#[derive(Job)]`. Turns out `job!` was able to generate all the cod we needed.
+- Change `jobs!` to also require the argument type that your job expects. This mean you'll no longer be able to enqueue your jobs with the wrong type of arguments.
 
 ### Deprecated
 

--- a/robin/examples/client_and_worker.rs
+++ b/robin/examples/client_and_worker.rs
@@ -35,7 +35,7 @@ fn client(config: Config) {
 }
 
 jobs! {
-    MyJob,
+    MyJob(JobArgs),
 }
 
 impl MyJob {

--- a/robin/src/macros.rs
+++ b/robin/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! jobs {
     (
-        $($id:ident,)*
+        $($id:ident($arg_type:ty),)*
     ) => {
         $(
             pub struct $id;
@@ -21,8 +21,8 @@ macro_rules! jobs {
             impl $id {
                 #[allow(dead_code)]
                 #[inline]
-                pub fn perform_now<A: Serialize>(
-                    args: A,
+                pub fn perform_now(
+                    args: &$arg_type,
                     con: &WorkerConnection,
                 ) -> RobinResult<()> {
                     $id.perform_now(args, con)
@@ -30,8 +30,8 @@ macro_rules! jobs {
 
                 #[allow(dead_code)]
                 #[inline]
-                pub fn perform_later<A: Serialize>(
-                    args: A,
+                pub fn perform_later(
+                    args: &$arg_type,
                     con: &WorkerConnection,
                 ) -> RobinResult<()> {
                     $id.perform_later(args, con)

--- a/robin/tests/performing_jobs_test.rs
+++ b/robin/tests/performing_jobs_test.rs
@@ -134,7 +134,7 @@ fn jobs_with_unit_as_args() {
     use robin::error::Error;
 
     jobs! {
-        JobWithoutArgs,
+        JobWithoutArgs(()),
     }
 
     impl JobWithoutArgs {

--- a/robin/tests/test_helper/mod.rs
+++ b/robin/tests/test_helper/mod.rs
@@ -57,9 +57,9 @@ pub trait WithTempFile {
 }
 
 jobs! {
-    VerifyableJob,
-    PassSecondTime,
-    FailForever,
+    VerifyableJob(VerifyableJobArgs),
+    PassSecondTime(PassSecondTimeArgs),
+    FailForever(FailForeverArgs),
 }
 
 pub fn assert_verifiable_job_performed_with(args: &VerifyableJobArgs) {


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/robin/issues/49

Previously it was possible to enqueue all types of jobs with anything that
implemented `Serialize` and `Deserialize`. That wasn't very type safe
and runtime crashes waiting to happen.

This changes the `jobs!` macro such that you also have to supply the
type of argument your job expects. That way we can generate the code for
`::perform_later` and `::perform_now` to use that type for the argument.