### PR TITLE
Add module for internal macros

### DIFF
--- a/robin/src/internal_macros.rs
+++ b/robin/src/internal_macros.rs
@@ -1,0 +1,60 @@
+/// A useful macro for doing "puts debugging".
+///
+/// This:
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate robin;
+/// #
+/// # fn main() {
+/// #[derive(Debug)]
+/// struct Foo;
+///
+/// let a = Foo;
+///
+/// p!(a);
+/// # }
+/// ```
+///
+/// Is the same as:
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate robin;
+/// #
+/// # fn main() {
+/// #[derive(Debug)]
+/// struct Foo;
+///
+/// let a = Foo;
+///
+/// println!("a = {:?}", a);
+/// # }
+/// ```
+///
+/// The macro also accepts multiple arguments and will print each on its own line:
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate robin;
+/// #
+/// # fn main() {
+/// #[derive(Debug)]
+/// struct Foo;
+///
+/// let a = Foo;
+/// let b = Foo;
+/// let c = Foo;
+///
+/// p!(a, b, c);
+/// # }
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! p {
+    ( $($var:ident),* ) => {
+        $(
+            println!(concat!(stringify!($var), " = {:?}"), $var);
+        )*
+    }
+}

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -124,6 +124,11 @@ pub mod macros;
 mod ticker;
 mod queue_adapters;
 
+#[doc(hidden)]
+#[macro_use]
+#[cfg(not(release))]
+mod internal_macros;
+
 pub mod prelude {
     //! Reexports the most commonly used types and traits from the other modules.
     //! As long as you're doing standard things this is the only `use` you'll need.


### PR DESCRIPTION
I found this `p!` macro very helpful during debugging and this new
module gives macros like that a place to live.