### PR TITLE
Make connections generic over job queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 - Added `worker::spawn_workers` which is useful during testing. See the docs for more info.
 - Add trait `JobQueueErrorInformation`. The errors returned from job queues will implement this trait, and provide a bit more information about exactly what happened.
+- `Connection` now has `delete`, `size`, and `empty` methods for both the main and retry queues.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 - Make the `connections::queue_adapters` module private. There is no reason for users to depend on this.
 - We now use the [log crate](https://crates.io/crates/log) for all logging.
 - We now spawn a dedicated worker that only operates on the retry queue. That means if `config.worker_count` is 10 you'll actually get 11 workers.
+- `WorkerConnection` has been renamed to `Connection`.
+- `Connection` is now generic over the type of jobs backend. See the docs for the minor change if you need to make to continue using Redis. In the future we will provide other job backends than Redis.
+- The value contained inside an `Error::UnknownJob` has been changed from a `String` to a `JobName`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,24 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 ### Added
 
 - Added `worker::spawn_workers` which is useful during testing. See the docs for more info.
+- Add trait `JobQueueErrorInformation`. The errors returned from job queues will implement this trait, and provide a bit more information about exactly what happened.
 
 ### Changed
 
-- Remove `#[derive(Job)]`. Turns out `job!` was able to generate all the cod we needed.
 - Change `jobs!` to also require the argument type that your job expects. This mean you'll no longer be able to enqueue your jobs with the wrong type of arguments.
 - Remove the export of `serde::Serialize` from `prelude` since it is no longer necessary due to [#50](https://github.com/davidpdrsn/robin/pull/50).
-- Make the `connections::queue_adapters` module private. There is no reason for users to depend on this.
 - We now use the [log crate](https://crates.io/crates/log) for all logging.
 - We now spawn a dedicated worker that only operates on the retry queue. That means if `config.worker_count` is 10 you'll actually get 11 workers.
 - `WorkerConnection` has been renamed to `Connection`.
 - `Connection` is now generic over the type of jobs backend. See the docs for the minor change if you need to make to continue using Redis. In the future we will provide other job backends than Redis.
 - The value contained inside an `Error::UnknownJob` has been changed from a `String` to a `JobName`.
 - `Error::SerdeJsonError` has been renamed to `Error::SerdeError`.
+
+### Removed
+
+- Remove `#[derive(Job)]`. Turns out `job!` was able to generate all the cod we needed.
 - The variants `Error::UnknownRedisError` and `Error::RedisError` has been removed. They are replaced with `JobQueueError` and `JobQueueErrorInformation`.
-
-### Deprecated
-
-N/A
+- Make the `connections::queue_adapters` module private. There is no reason for users to depend on this.
 
 ### Fixed
 
@@ -45,7 +45,7 @@ N/A
 
 - `Config.worker_count` will now default to number of CPUs.
 
-### Deprecated
+### Removed
 
 N/A
 
@@ -66,7 +66,7 @@ N/A
 - Functions that previously took the connection in the first place, and job arguments in the second place now take the connection in the last place. That was mainly `perform_now` and `perform_later`.
 - The error type in `JobResult` has been changed from `String` to `Box<std::error::Error>`. Allows clients to keep using their own error types without having to map errors to strings all the time.
 
-### Deprecated
+### Removed
 
 N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 - `WorkerConnection` has been renamed to `Connection`.
 - `Connection` is now generic over the type of jobs backend. See the docs for the minor change if you need to make to continue using Redis. In the future we will provide other job backends than Redis.
 - The value contained inside an `Error::UnknownJob` has been changed from a `String` to a `JobName`.
+- `Error::SerdeJsonError` has been renamed to `Error::SerdeError`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 - `Connection` is now generic over the type of jobs backend. See the docs for the minor change if you need to make to continue using Redis. In the future we will provide other job backends than Redis.
 - The value contained inside an `Error::UnknownJob` has been changed from a `String` to a `JobName`.
 - `Error::SerdeJsonError` has been renamed to `Error::SerdeError`.
+- The variants `Error::UnknownRedisError` and `Error::RedisError` has been removed. They are replaced with `JobQueueError` and `JobQueueErrorInformation`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 - Remove `#[derive(Job)]`. Turns out `job!` was able to generate all the cod we needed.
 - The variants `Error::UnknownRedisError` and `Error::RedisError` has been removed. They are replaced with `JobQueueError` and `JobQueueErrorInformation`.
 - Make the `connections::queue_adapters` module private. There is no reason for users to depend on this.
+- `Connection::size` has been made private. Instead call `Connection::main_queue_size` or `Connection::retry_queue_size` depending on what you want.
+- `QueueIdentifier::redis_queue_name`. The redis queue type now handles this internally.
 
 ### Fixed
 

--- a/robin-derives/src/each_variant.rs
+++ b/robin-derives/src/each_variant.rs
@@ -1,5 +1,5 @@
-use syn::*;
 use quote::Tokens;
+use syn::*;
 
 pub fn derive(input: DeriveInput) -> Tokens {
     let name: &Ident = &input.ident;

--- a/robin-derives/src/lib.rs
+++ b/robin-derives/src/lib.rs
@@ -6,8 +6,8 @@ extern crate syn;
 mod each_variant;
 
 use proc_macro::TokenStream;
-use syn::*;
 use quote::Tokens;
+use syn::*;
 
 #[doc(hidden)]
 #[proc_macro_derive(EachVariant)]

--- a/robin/examples/client_and_worker.rs
+++ b/robin/examples/client_and_worker.rs
@@ -21,12 +21,12 @@ fn main() {
 }
 
 fn worker(config: Config) {
-    let queue_init = RedisQueueInit::default();
+    let queue_init = RedisConfig::default();
     robin_boot_worker!(RedisQueue, &config, queue_init);
 }
 
 fn client(config: Config) {
-    let queue_init = RedisQueueInit::default();
+    let queue_init = RedisConfig::default();
     let con =
         robin_establish_connection!(RedisQueue, config, queue_init).expect("Failed to connect");
 

--- a/robin/examples/client_and_worker.rs
+++ b/robin/examples/client_and_worker.rs
@@ -21,14 +21,14 @@ fn main() {
 }
 
 fn worker(config: Config) {
-    let queue_init = RedisConfig::default();
-    robin_boot_worker!(RedisQueue, &config, queue_init);
+    let queue_config = RedisConfig::default();
+    robin_boot_worker!(RedisQueue, &config, queue_config);
 }
 
 fn client(config: Config) {
-    let queue_init = RedisConfig::default();
+    let queue_config = RedisConfig::default();
     let con =
-        robin_establish_connection!(RedisQueue, config, queue_init).expect("Failed to connect");
+        robin_establish_connection!(RedisQueue, config, queue_config).expect("Failed to connect");
 
     let n = 10;
 

--- a/robin/examples/client_and_worker.rs
+++ b/robin/examples/client_and_worker.rs
@@ -4,6 +4,7 @@ extern crate robin;
 extern crate serde_derive;
 
 use robin::prelude::*;
+use robin::redis_queue::*;
 use std::env;
 
 fn main() {
@@ -20,11 +21,14 @@ fn main() {
 }
 
 fn worker(config: Config) {
-    robin_boot_worker!(&config);
+    let queue_init = RedisQueueInit::default();
+    robin_boot_worker!(RedisQueue, &config, queue_init);
 }
 
 fn client(config: Config) {
-    let con = robin_establish_connection!(config).expect("Failed to connect");
+    let queue_init = RedisQueueInit::default();
+    let con =
+        robin_establish_connection!(RedisQueue, config, queue_init).expect("Failed to connect");
 
     let n = 10;
 
@@ -39,7 +43,7 @@ jobs! {
 }
 
 impl MyJob {
-    fn perform(args: JobArgs, _con: &WorkerConnection) -> JobResult {
+    fn perform<Q>(args: JobArgs, _con: &Connection<Q>) -> JobResult {
         println!("Job performed with {:?}", args);
         Ok(())
     }

--- a/robin/src/config.rs
+++ b/robin/src/config.rs
@@ -1,5 +1,5 @@
-use std::default::Default;
 use num_cpus;
+use std::default::Default;
 
 /// Configuration options used throughout Robin.
 ///

--- a/robin/src/config.rs
+++ b/robin/src/config.rs
@@ -23,8 +23,10 @@ pub struct Config {
     /// so you shouldn't need to configure this.
     pub timeout: usize,
 
-    /// Namespace used for all Redis values.
-    pub redis_namespace: String,
+    /// Whether or not to repeat looking for jobs when the timeout is hit. This
+    /// defaults to `true` and should probably remain that way.
+    /// This is used when testing Robin internally.
+    pub repeat_on_timeout: bool,
 
     /// The maximum number of times a job will be retried. After that it will discarded.
     pub retry_count_limit: u32,
@@ -33,19 +35,15 @@ pub struct Config {
     /// connection, so make sure you have enough connections available.
     /// Defaults to the number of CPUs your machine has.
     pub worker_count: usize,
-
-    /// The URL that will be used to connect to Redis.
-    pub redis_url: String,
 }
 
 impl Default for Config {
     fn default() -> Config {
         Config {
             timeout: 30,
-            redis_namespace: "robin_".to_string(),
+            repeat_on_timeout: true,
             retry_count_limit: 10,
             worker_count: num_cpus::get(),
-            redis_url: "redis://127.0.0.1/".to_string(),
         }
     }
 }

--- a/robin/src/config.rs
+++ b/robin/src/config.rs
@@ -13,21 +13,10 @@ use num_cpus;
 /// config.worker_count = 10;
 ///
 /// assert_eq!(config.worker_count, 10);
-/// assert_eq!(config.timeout, 30);
 /// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// The number of seconds the worker will block while waiting for a new job
-    /// to be enqueued. By default workers will retry after the timeout is hit,
-    /// so you shouldn't need to configure this.
-    pub timeout: usize,
-
-    /// Whether or not to repeat looking for jobs when the timeout is hit. This
-    /// defaults to `true` and should probably remain that way.
-    /// This is used when testing Robin internally.
-    pub repeat_on_timeout: bool,
-
     /// The maximum number of times a job will be retried. After that it will discarded.
     pub retry_count_limit: u32,
 
@@ -40,8 +29,6 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            timeout: 30,
-            repeat_on_timeout: true,
             retry_count_limit: 10,
             worker_count: num_cpus::get(),
         }

--- a/robin/src/config.rs
+++ b/robin/src/config.rs
@@ -15,7 +15,7 @@ use num_cpus;
 /// assert_eq!(config.worker_count, 10);
 /// # }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Config {
     /// The maximum number of times a job will be retried. After that it will discarded.
     pub retry_count_limit: u32,

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -89,7 +89,7 @@ where
         let name = enq_job.name().to_string();
 
         let job = self.lookup_job(&JobName::from(name.clone()))
-            .ok_or_else(move || Error::UnknownJob(name))
+            .ok_or_else(move || Error::UnknownJob(JobName(name)))
             .map_err(NoJobDequeued::from)?;
 
         Ok((job, args, enq_job.retry_count().clone()))

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -1,8 +1,8 @@
 use config::Config;
 use error::*;
 use job::*;
-use queue_adapters::{DequeueTimeout, EnqueuedJob, JobQueue, NoJobDequeued, QueueIdentifier,
-                     RetryCount, redis_queue::RedisQueue};
+use queue_adapters::{EnqueuedJob, JobQueue, NoJobDequeued, QueueIdentifier, RetryCount,
+                     redis_queue::RedisQueue};
 
 /// Create a new connection.
 ///
@@ -82,9 +82,8 @@ where
     pub fn dequeue_from<'a>(
         &'a self,
         iden: QueueIdentifier,
-        timeout: DequeueTimeout,
     ) -> Result<(Box<Job<Q> + Send>, String, RetryCount), NoJobDequeued> {
-        let enq_job = self.queue.dequeue(&timeout, iden)?;
+        let enq_job = self.queue.dequeue(iden)?;
 
         let args = enq_job.args().to_string();
         let name = enq_job.name().to_string();

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -91,8 +91,7 @@ where
         let name = enq_job.name().to_string();
 
         let job = self.lookup_job(&JobName::from(name.clone()))
-            .ok_or_else(move || Error::UnknownJob(JobName(name)))
-            .map_err(NoJobDequeued::from)?;
+            .ok_or_else(move || NoJobDequeued::BecauseUnknownJob(JobName(name)))?;
 
         Ok((job, args, enq_job.retry_count().clone()))
     }

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -16,14 +16,14 @@ use queue_adapters::{DequeueTimeout, EnqueuedJob, JobQueue, NoJobDequeued, Queue
 /// [`robin_boot_worker!`](../macro.robin_boot_worker.html).
 pub fn establish<L, Q, K>(
     config: Config,
-    queue_init: K,
+    queue_config: K,
     lookup_job: L,
 ) -> RobinResult<Connection<Q>>
 where
     L: 'static + LookupJob<Q>,
-    Q: JobQueue<Init = K>,
+    Q: JobQueue<Config = K>,
 {
-    JobQueue::new(&queue_init).map(|queue| Connection {
+    JobQueue::new(&queue_config).map(|queue| Connection {
         queue: queue,
         config: config,
         lookup_job: Box::new(lookup_job),

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -104,10 +104,22 @@ where
         Ok((job, args, enq_job.retry_count().clone()))
     }
 
+    /// Delete all jobs from main queue
+    pub fn delete_all_from_main(&self) -> RobinResult<()> {
+        self.main_queue.delete_all()?;
+        Ok(())
+    }
+
+    /// Delete all jobs from retry queue
+    pub fn delete_all_from_retry(&self) -> RobinResult<()> {
+        self.retry_queue.delete_all()?;
+        Ok(())
+    }
+
     /// Delete all jobs from all queues
     pub fn delete_all(&self) -> RobinResult<()> {
-        self.main_queue.delete_all()?;
-        self.retry_queue.delete_all()?;
+        self.delete_all_from_main()?;
+        self.delete_all_from_retry()?;
         Ok(())
     }
 
@@ -116,14 +128,22 @@ where
         self.size(QueueIdentifier::Main).map_err(Error::from)
     }
 
-    /// The number of jobs in the retry queue
+    /// The number of jobs in the main queue
     pub fn retry_queue_size(&self) -> RobinResult<usize> {
         self.size(QueueIdentifier::Retry).map_err(Error::from)
     }
 
-    /// `true` if there are 0 jobs in the queue, `false` otherwise
-    pub fn is_queue_empty(&self) -> RobinResult<bool> {
+    /// `true` if there are 0 jobs in the main queue, `false` otherwise
+    pub fn is_main_queue_empty(&self) -> RobinResult<bool> {
         self.main_queue
+            .size()
+            .map_err(Error::from)
+            .map(|size| size == 0)
+    }
+
+    /// `true` if there are 0 jobs in the retry queue, `false` otherwise
+    pub fn is_retry_queue_empty(&self) -> RobinResult<bool> {
+        self.retry_queue
             .size()
             .map_err(Error::from)
             .map(|size| size == 0)

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -125,40 +125,38 @@ where
 
     /// The number of jobs in the main queue
     pub fn main_queue_size(&self) -> RobinResult<usize> {
-        self.size(QueueIdentifier::Main).map_err(Error::from)
+        self.size(QueueIdentifier::Main)
     }
 
     /// The number of jobs in the main queue
     pub fn retry_queue_size(&self) -> RobinResult<usize> {
-        self.size(QueueIdentifier::Retry).map_err(Error::from)
+        self.size(QueueIdentifier::Retry)
     }
 
     /// `true` if there are 0 jobs in the main queue, `false` otherwise
     pub fn is_main_queue_empty(&self) -> RobinResult<bool> {
-        self.main_queue
-            .size()
-            .map_err(Error::from)
-            .map(|size| size == 0)
+        self.is_empty(QueueIdentifier::Main)
     }
 
     /// `true` if there are 0 jobs in the retry queue, `false` otherwise
     pub fn is_retry_queue_empty(&self) -> RobinResult<bool> {
-        self.retry_queue
-            .size()
-            .map_err(Error::from)
-            .map(|size| size == 0)
+        self.is_empty(QueueIdentifier::Retry)
     }
 
     fn lookup_job(&self, name: &JobName) -> Option<Box<Job<Q> + Send>> {
         self.lookup_job.lookup(name)
     }
 
-    /// The number of jobs in the queue
+    fn is_empty(&self, iden: QueueIdentifier) -> RobinResult<bool> {
+        self.size(iden).map(|size| size == 0)
+    }
+
     fn size(&self, iden: QueueIdentifier) -> RobinResult<usize> {
         match iden {
-            QueueIdentifier::Main => self.main_queue.size(),
-            QueueIdentifier::Retry => self.retry_queue.size(),
-        }.map_err(Error::from)
+            QueueIdentifier::Main => &self.main_queue,
+            QueueIdentifier::Retry => &self.retry_queue,
+        }.size()
+            .map_err(Error::from)
     }
 }
 

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -1,8 +1,8 @@
 use config::Config;
 use error::*;
 use job::*;
-use queue_adapters::{EnqueuedJob, JobQueue, NoJobDequeued, QueueIdentifier, RetryCount,
-                     redis_queue::RedisQueue};
+use queue_adapters::{redis_queue::RedisQueue, EnqueuedJob, JobQueue, NoJobDequeued,
+                     QueueIdentifier, RetryCount};
 
 /// Create a new connection.
 ///

--- a/robin/src/error.rs
+++ b/robin/src/error.rs
@@ -1,6 +1,7 @@
 use serde_json;
 use redis;
 use std::{self, fmt};
+use job::JobName;
 
 /// The result type used throughout Robin.
 pub type RobinResult<T> = Result<T, Error>;
@@ -9,7 +10,7 @@ pub type RobinResult<T> = Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     /// The job we got from the queue isn't known.
-    UnknownJob(String),
+    UnknownJob(JobName),
 
     /// The job failed to perform and might be retried.
     JobFailed(Box<std::error::Error>),
@@ -33,7 +34,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         match self {
-            &Error::UnknownJob(ref name) => name,
+            &Error::UnknownJob(ref name) => &name.0,
             &Error::JobFailed(ref err) => err.description(),
             &Error::SerdeJsonError(ref err) => err.description(),
             &Error::RedisError(ref err) => err.description(),

--- a/robin/src/error.rs
+++ b/robin/src/error.rs
@@ -1,6 +1,6 @@
+use queue_adapters::{JobQueueError, JobQueueErrorInformation};
 use serde_json;
 use std::{error, fmt};
-use queue_adapters::{JobQueueError, JobQueueErrorInformation};
 
 /// The result type used throughout Robin.
 pub type RobinResult<T> = Result<T, Error>;

--- a/robin/src/error.rs
+++ b/robin/src/error.rs
@@ -1,7 +1,5 @@
 use serde_json;
-use redis;
 use std::{error, fmt};
-use job::JobName;
 use queue_adapters::{JobQueueError, JobQueueErrorInformation};
 
 /// The result type used throughout Robin.

--- a/robin/src/internal_macros.rs
+++ b/robin/src/internal_macros.rs
@@ -76,24 +76,24 @@ macro_rules! p {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! test_type_impls {
-    ( $name:ident, $type:ty, $trait:ty ) => {
+    ($name:ident, $type:ty, $trait:ty) => {
         #[allow(warnings)]
         fn $name() {
             let x: $type = unimplemented!();
             let _: &$trait = &x;
         }
-    }
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! robin_test {
-    ( $name:ident, $body:expr ) => {
+    ($name:ident, $body:expr) => {
         #[test]
         fn $name() {
             setup();
             $body();
             teardown();
         }
-    }
+    };
 }

--- a/robin/src/job.rs
+++ b/robin/src/job.rs
@@ -1,9 +1,9 @@
 extern crate serde_json;
 
-use serde::{Deserialize, Serialize};
 use connection::Connection;
-use queue_adapters::{JobQueue, QueueIdentifier, RetryCount};
 use error::{Error, RobinResult};
+use queue_adapters::{JobQueue, QueueIdentifier, RetryCount};
+use serde::{Deserialize, Serialize};
 use std;
 
 /// The result type returned when performing jobs

--- a/robin/src/job.rs
+++ b/robin/src/job.rs
@@ -30,13 +30,13 @@ impl Args {
     /// Generic function for deserializing the encoded arguments into the type
     /// required by the job.
     ///
-    /// Will return `Err(Error::SerdeJsonError(_))` if deserialization fails.
+    /// Will return `Err(Error::SerdeError(_))` if deserialization fails.
     /// This will most likely happen if a given job doesn't support the arguments type you're
     /// trying to deserialize into.
     pub fn deserialize<'a, T: Deserialize<'a>>(&'a self) -> RobinResult<T> {
         match serde_json::from_str(&self.json) {
             Ok(v) => Ok(v),
-            Err(e) => Err(Error::SerdeJsonError(e)),
+            Err(e) => Err(Error::SerdeError(e)),
         }
     }
 }

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -1,6 +1,6 @@
-// #![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
-//         trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
-//         unused_import_braces, unused_qualifications)]
+#![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
+        trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
+        unused_import_braces, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/robin/0.3.0")]
 
 //! # Robin
@@ -153,6 +153,7 @@ pub mod prelude {
     pub use config::Config;
 }
 
+/// Contains the types you'll need if you wish to use Redis as your backend.
 pub mod redis_queue {
     pub use queue_adapters::redis_queue::{RedisConfig, RedisQueue};
 }

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -1,6 +1,8 @@
-#![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
-        trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
-        unused_import_braces, unused_qualifications)]
+#![deny(
+    missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
+    trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+    unused_qualifications
+)]
 #![doc(html_root_url = "https://docs.rs/robin/0.3.0")]
 
 //! # Robin
@@ -145,12 +147,12 @@ pub mod prelude {
     //! Reexports the most commonly used types and traits from the other modules.
     //! As long as you're doing standard things this is the only `use` you'll need.
 
-    pub use job::{Args, Job, JobName, JobResult, PerformJob};
-    pub use error::RobinResult;
+    pub use config::Config;
     pub use connection::{establish, Connection, LookupJob};
+    pub use error::RobinResult;
+    pub use job::{Args, Job, JobName, JobResult, PerformJob};
     pub use queue_adapters::JobQueue;
     pub use worker::{boot, spawn_workers};
-    pub use config::Config;
 }
 
 /// Contains the types you'll need if you wish to use Redis as your backend.

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -49,12 +49,12 @@
 //! }
 //!
 //! let config = Config::default();
-//! let queue_init = RedisQueueInit::default();
+//! let queue_init = RedisConfig::default();
 //! #
 //! # let mut config = Config::default();
 //! # config.timeout = 1;
 //! #
-//! # let mut queue_init = RedisQueueInit::default();
+//! # let mut queue_init = RedisConfig::default();
 //! # queue_init.namespace = "doc_tests_for_crate".to_string();
 //!
 //! let con = robin_establish_connection!(RedisQueue, config, queue_init)?;
@@ -156,5 +156,5 @@ pub mod prelude {
 }
 
 pub mod redis_queue {
-    pub use queue_adapters::redis_queue::{RedisQueue, RedisQueueInit};
+    pub use queue_adapters::redis_queue::{RedisConfig, RedisQueue};
 }

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -49,13 +49,11 @@
 //! }
 //!
 //! let config = Config::default();
+//! #
 //! let queue_config = RedisConfig::default();
-//! #
-//! # let mut config = Config::default();
-//! # config.timeout = 1;
-//! #
 //! # let mut queue_config = RedisConfig::default();
 //! # queue_config.namespace = "doc_tests_for_crate".to_string();
+//! # queue_config.timeout = 1;
 //!
 //! let con = robin_establish_connection!(RedisQueue, config, queue_config)?;
 //! # con.delete_all();

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -157,3 +157,9 @@ pub mod prelude {
 pub mod redis_queue {
     pub use queue_adapters::redis_queue::{RedisConfig, RedisQueue};
 }
+
+/// Contains the types you'll need if you wish to use Robins in-memory queue. Usually only used for
+/// testing.
+pub mod memory_queue {
+    pub use queue_adapters::memory_queue::{MemoryQueue, MemoryQueueConfig};
+}

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -49,15 +49,15 @@
 //! }
 //!
 //! let config = Config::default();
-//! let queue_init = RedisConfig::default();
+//! let queue_config = RedisConfig::default();
 //! #
 //! # let mut config = Config::default();
 //! # config.timeout = 1;
 //! #
-//! # let mut queue_init = RedisConfig::default();
-//! # queue_init.namespace = "doc_tests_for_crate".to_string();
+//! # let mut queue_config = RedisConfig::default();
+//! # queue_config.namespace = "doc_tests_for_crate".to_string();
 //!
-//! let con = robin_establish_connection!(RedisQueue, config, queue_init)?;
+//! let con = robin_establish_connection!(RedisQueue, config, queue_config)?;
 //! # con.delete_all();
 //!
 //! assert_eq!(con.main_queue_size()?, 0);
@@ -73,11 +73,11 @@
 //! # if true {
 //! # robin::worker::spawn_workers::<RedisQueue, _, _>(
 //! #     &config.clone(),
-//! #     queue_init.clone(),
+//! #     queue_config.clone(),
 //! #     __robin_lookup_job,
 //! # ).perform_all_jobs_and_die();
 //! # } else {
-//! robin_boot_worker!(RedisQueue, config, queue_init);
+//! robin_boot_worker!(RedisQueue, config, queue_config);
 //! # }
 //!
 //! assert_eq!(con.main_queue_size()?, 0);

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -1,6 +1,6 @@
-// #![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
-//         trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
-//         unused_import_braces, unused_qualifications)]
+#![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
+        trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
+        unused_import_braces, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/robin/0.3.0")]
 
 //! # Robin

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -1,6 +1,6 @@
-#![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
-        trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
-        unused_import_braces, unused_qualifications)]
+// #![deny(missing_docs, unused_imports, missing_debug_implementations, missing_copy_implementations,
+//         trivial_casts, trivial_numeric_casts, unsafe_code, unstable_features,
+//         unused_import_braces, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/robin/0.3.0")]
 
 //! # Robin

--- a/robin/src/macros.rs
+++ b/robin/src/macros.rs
@@ -304,7 +304,7 @@ macro_rules! jobs {
 /// #     Android,
 /// # }
 /// let config = Config::default();
-/// let queue_init = RedisQueueInit::default();
+/// let queue_init = RedisConfig::default();
 ///
 /// let con = robin_establish_connection!(RedisQueue, config, queue_init)?;
 ///
@@ -360,8 +360,8 @@ macro_rules! robin_establish_connection {
 /// # config.retry_count_limit = 1;
 /// # config.worker_count = 1;
 /// #
-/// let queue_init = RedisQueueInit::default();
-/// # let mut queue_init = RedisQueueInit::default();
+/// let queue_init = RedisConfig::default();
+/// # let mut queue_init = RedisConfig::default();
 /// # queue_init.namespace = "doc_tests_for_boot_worker_macro".to_string();
 ///
 /// # if false {

--- a/robin/src/macros.rs
+++ b/robin/src/macros.rs
@@ -319,16 +319,14 @@ macro_rules! jobs {
 /// ```
 #[macro_export]
 macro_rules! robin_establish_connection {
-    ($ty:ty, $config:expr, $queue_config:expr) => (
-        {
-            let con: RobinResult<Connection<$ty>> = robin::connection::establish(
-                $config.clone(),
-                $queue_config.clone(),
-                __robin_lookup_job,
-            );
-            con
-        }
-    )
+    ($ty:ty, $config:expr, $queue_config:expr) => {{
+        let con: RobinResult<Connection<$ty>> = robin::connection::establish(
+            $config.clone(),
+            $queue_config.clone(),
+            __robin_lookup_job,
+        );
+        con
+    }};
 }
 
 /// Boots the worker which performs the jobs.
@@ -371,11 +369,11 @@ macro_rules! robin_establish_connection {
 /// ```
 #[macro_export]
 macro_rules! robin_boot_worker {
-    ($ty:ty, $config:expr, $queue_config:expr) => (
+    ($ty:ty, $config:expr, $queue_config:expr) => {
         robin::worker::boot::<$ty, _, _>(
             &$config.clone(),
             $queue_config.clone(),
             __robin_lookup_job,
         );
-    )
+    };
 }

--- a/robin/src/macros.rs
+++ b/robin/src/macros.rs
@@ -356,13 +356,13 @@ macro_rules! robin_establish_connection {
 /// # }
 /// let config = Config::default();
 /// # let mut config = Config::default();
-/// # config.timeout = 1;
 /// # config.retry_count_limit = 1;
 /// # config.worker_count = 1;
 /// #
 /// let queue_config = RedisConfig::default();
 /// # let mut queue_config = RedisConfig::default();
 /// # queue_config.namespace = "doc_tests_for_boot_worker_macro".to_string();
+/// # queue_config.timeout = 1;
 ///
 /// # if false {
 /// robin_boot_worker!(RedisQueue, config, queue_config);

--- a/robin/src/macros.rs
+++ b/robin/src/macros.rs
@@ -304,9 +304,9 @@ macro_rules! jobs {
 /// #     Android,
 /// # }
 /// let config = Config::default();
-/// let queue_init = RedisConfig::default();
+/// let queue_config = RedisConfig::default();
 ///
-/// let con = robin_establish_connection!(RedisQueue, config, queue_init)?;
+/// let con = robin_establish_connection!(RedisQueue, config, queue_config)?;
 ///
 /// let args = SendPushNotificationArgs {
 ///     device_id: "123".to_string(),
@@ -319,11 +319,11 @@ macro_rules! jobs {
 /// ```
 #[macro_export]
 macro_rules! robin_establish_connection {
-    ($ty:ty, $config:expr, $queue_init:expr) => (
+    ($ty:ty, $config:expr, $queue_config:expr) => (
         {
             let con: RobinResult<Connection<$ty>> = robin::connection::establish(
                 $config.clone(),
-                $queue_init.clone(),
+                $queue_config.clone(),
                 __robin_lookup_job,
             );
             con
@@ -360,18 +360,22 @@ macro_rules! robin_establish_connection {
 /// # config.retry_count_limit = 1;
 /// # config.worker_count = 1;
 /// #
-/// let queue_init = RedisConfig::default();
-/// # let mut queue_init = RedisConfig::default();
-/// # queue_init.namespace = "doc_tests_for_boot_worker_macro".to_string();
+/// let queue_config = RedisConfig::default();
+/// # let mut queue_config = RedisConfig::default();
+/// # queue_config.namespace = "doc_tests_for_boot_worker_macro".to_string();
 ///
 /// # if false {
-/// robin_boot_worker!(RedisQueue, config, queue_init);
+/// robin_boot_worker!(RedisQueue, config, queue_config);
 /// # }
 /// # }
 /// ```
 #[macro_export]
 macro_rules! robin_boot_worker {
-    ($ty:ty, $config:expr, $queue_init:expr) => (
-        robin::worker::boot::<$ty, _, _>(&$config.clone(), $queue_init.clone(), __robin_lookup_job);
+    ($ty:ty, $config:expr, $queue_config:expr) => (
+        robin::worker::boot::<$ty, _, _>(
+            &$config.clone(),
+            $queue_config.clone(),
+            __robin_lookup_job,
+        );
     )
 }

--- a/robin/src/queue_adapters/memory_queue.rs
+++ b/robin/src/queue_adapters/memory_queue.rs
@@ -32,7 +32,7 @@ impl MemoryQueueConfig {
 
 impl MemoryQueueConfig {
     fn enqueue(&self, enq_job: EnqueuedJob, iden: QueueIdentifier) -> RobinResult<()> {
-        self.send.lock().unwrap().send(enq_job);
+        self.send.lock().unwrap().send(enq_job).unwrap();
         Ok(())
     }
 

--- a/robin/src/queue_adapters/memory_queue.rs
+++ b/robin/src/queue_adapters/memory_queue.rs
@@ -1,8 +1,11 @@
 #![allow(unused_imports)]
-use error::*;
 use super::*;
-use std::{sync::{Arc, Mutex, mpsc::{channel, Receiver, SendError, Sender}}, time::Duration};
+use error::*;
 use std::default::Default;
+use std::{sync::{mpsc::{channel, Receiver, SendError, Sender},
+                 Arc,
+                 Mutex},
+          time::Duration};
 
 /// A queue backend the stores the jobs in-memory. Normally only used during testing.
 #[allow(missing_debug_implementations)]

--- a/robin/src/queue_adapters/memory_queue.rs
+++ b/robin/src/queue_adapters/memory_queue.rs
@@ -1,0 +1,139 @@
+use error::*;
+use super::{EnqueuedJob, JobQueue, NoJobDequeued, QueueIdentifier};
+use std::{sync::{Mutex, mpsc::{channel, Receiver, Sender}}, time::Duration};
+use std::default::Default;
+
+/// A queue backend the stores the jobs in-memory. Normally only used during testing.
+#[allow(missing_debug_implementations)]
+pub struct MemoryQueue {
+    send: Mutex<Sender<EnqueuedJob>>,
+    recv: Mutex<Receiver<EnqueuedJob>>,
+    config: Mutex<MemoryQueueConfig>,
+}
+
+/// The type used to configure an in-memory queue.
+#[derive(Clone, Debug, Copy)]
+pub struct MemoryQueueConfig {
+    /// The time duration the worker will block while waiting for a new job to be enqueued.
+    pub timeout: Duration,
+}
+
+impl Default for MemoryQueueConfig {
+    fn default() -> MemoryQueueConfig {
+        MemoryQueueConfig {
+            timeout: Duration::from_secs(1),
+        }
+    }
+}
+
+impl JobQueue for MemoryQueue {
+    type Config = MemoryQueueConfig;
+
+    fn new(config: &MemoryQueueConfig) -> RobinResult<Self> {
+        let (send, recv) = channel();
+
+        Ok(MemoryQueue {
+            send: Mutex::new(send),
+            recv: Mutex::new(recv),
+            config: Mutex::new(config.clone()),
+        })
+    }
+
+    fn enqueue(&self, enq_job: EnqueuedJob, iden: QueueIdentifier) -> RobinResult<()> {
+        self.send.lock().unwrap().send(enq_job);
+        Ok(())
+    }
+
+    fn dequeue(&self, iden: QueueIdentifier) -> Result<EnqueuedJob, NoJobDequeued> {
+        Ok(self.recv.lock().unwrap().recv().unwrap())
+    }
+
+    /// Delete all jobs from the queue.
+    ///
+    /// ```
+    /// # extern crate robin;
+    /// # use robin::prelude::*;
+    /// use robin::memory_queue::*;
+    /// use robin::queue_adapters::{EnqueuedJob, QueueIdentifier, RetryCount};
+    ///
+    /// # use std::error::Error;
+    /// # fn main() {
+    /// # try_main().unwrap();
+    /// # }
+    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// #
+    /// let config = MemoryQueueConfig::default();
+    /// let q = MemoryQueue::new(&config)?;
+    ///
+    /// let job = EnqueuedJob::new("name", "args", RetryCount::NeverRetried);
+    /// q.enqueue(job, QueueIdentifier::Main);
+    ///
+    /// assert_eq!(q.size(QueueIdentifier::Main)?, 1);
+    ///
+    /// q.delete_all(QueueIdentifier::Main);
+    ///
+    /// assert_eq!(q.size(QueueIdentifier::Main)?, 0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn delete_all(&self, iden: QueueIdentifier) -> RobinResult<()> {
+        let recv = self.recv.lock().unwrap();
+        loop {
+            if let Err(_) = recv.try_recv() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the number of jobs in the queue.
+    ///
+    /// ```
+    /// # extern crate robin;
+    /// # use robin::prelude::*;
+    /// use robin::memory_queue::*;
+    /// use robin::queue_adapters::{EnqueuedJob, QueueIdentifier, RetryCount};
+    ///
+    /// # use std::error::Error;
+    /// # fn main() {
+    /// # try_main().unwrap();
+    /// # }
+    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// #
+    /// let config = MemoryQueueConfig::default();
+    /// let q = MemoryQueue::new(&config)?;
+    ///
+    /// assert_eq!(q.size(QueueIdentifier::Main)?, 0);
+    ///
+    /// let job = EnqueuedJob::new("name", "args", RetryCount::NeverRetried);
+    /// q.enqueue(job, QueueIdentifier::Main);
+    ///
+    /// assert_eq!(q.size(QueueIdentifier::Main)?, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn size(&self, iden: QueueIdentifier) -> RobinResult<usize> {
+        let mut jobs = vec![];
+        let mut count = 0;
+
+        let recv = self.recv.lock().unwrap();
+        loop {
+            if let Ok(job) = recv.try_recv() {
+                count += 1;
+                jobs.push(job);
+            } else {
+                break;
+            }
+        }
+
+        let send = self.send.lock().unwrap();
+        for job in jobs {
+            send.send(job);
+        }
+
+        Ok(count)
+    }
+}
+
+test_type_impls!(memory_queue_impls_send, MemoryQueue, Send);
+test_type_impls!(memory_queue_impls_sync, MemoryQueue, Sync);

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -5,10 +5,11 @@ pub mod redis_queue;
 /// and therefore wont work across processes. Normally you'd only use this during testing.
 pub mod memory_queue;
 
-use job::JobName;
-use std::{error, fmt::{self, Debug}};
 use config::Config;
+use job::JobName;
 use std::marker::Sized;
+use std::{error,
+          fmt::{self, Debug}};
 
 /// Trait that represents a backend that can be used to store jobs.
 pub trait JobQueue

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -5,9 +5,6 @@ pub mod redis_queue;
 /// and therefore wont work across processes. Normally you'd only use this during testing.
 pub mod memory_queue;
 
-use serde_json;
-use redis;
-use error::*;
 use job::JobName;
 use std::{error, fmt::{self, Debug}};
 use config::Config;
@@ -107,10 +104,19 @@ impl error::Error for JobQueueErrorInformation {
 /// These should correspond 1-to-1 with the methods.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ErrorOrigin {
+    /// The error originated in the `new` method.
     Initialization,
+
+    /// The error originated in the `enqueue` method.
     Enqueue,
+
+    /// The error originated in the `dequeue` method.
     Dequeue,
+
+    /// The error originated in the `delete_all` method.
     DeleteAll,
+
+    /// The error originated in the `size` method.
     Size,
 }
 

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -17,11 +17,7 @@ where
 
     fn enqueue(&self, enq_job: EnqueuedJob, iden: QueueIdentifier) -> RobinResult<()>;
 
-    fn dequeue(
-        &self,
-        timeout: &DequeueTimeout,
-        iden: QueueIdentifier,
-    ) -> Result<EnqueuedJob, NoJobDequeued>;
+    fn dequeue(&self, iden: QueueIdentifier) -> Result<EnqueuedJob, NoJobDequeued>;
 
     fn delete_all(&self, iden: QueueIdentifier) -> RobinResult<()>;
 
@@ -108,11 +104,6 @@ impl From<Error> for NoJobDequeued {
         NoJobDequeued::BecauseError(error)
     }
 }
-
-/// New type wrapper around number of seconds to block when dequeueing a job.
-/// This gets constructed from the `Config`.
-#[derive(Debug, Copy, Clone)]
-pub struct DequeueTimeout(pub usize);
 
 /// The different queues supported by Robin.
 #[derive(EachVariant, Debug, Copy, Clone)]

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -7,20 +7,27 @@ use error::*;
 use config::Config;
 use std::marker::Sized;
 
+/// Trait that represents a backend that can be used to store jobs.
 pub trait JobQueue
 where
     Self: Sized,
 {
+    /// The type required to configure the queue.
     type Config;
 
+    /// Create a new queue with the given config.
     fn new(init: &Self::Config) -> RobinResult<Self>;
 
+    /// Push a job into the queue.
     fn enqueue(&self, enq_job: EnqueuedJob, iden: QueueIdentifier) -> RobinResult<()>;
 
+    /// Pull a job from the queue.
     fn dequeue(&self, iden: QueueIdentifier) -> Result<EnqueuedJob, NoJobDequeued>;
 
+    /// Delete all jobs from the queue.
     fn delete_all(&self, iden: QueueIdentifier) -> RobinResult<()>;
 
+    /// Get the number of jobs in the queue.
     fn size(&self, iden: QueueIdentifier) -> RobinResult<usize>;
 }
 

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -5,6 +5,28 @@ use serde_json;
 use redis;
 use error::*;
 use config::Config;
+use std::marker::Sized;
+
+pub trait JobQueue
+where
+    Self: Sized,
+{
+    type Init;
+
+    fn new(init: &Self::Init) -> RobinResult<Self>;
+
+    fn enqueue(&self, enq_job: EnqueuedJob, iden: QueueIdentifier) -> RobinResult<()>;
+
+    fn dequeue(
+        &self,
+        timeout: &DequeueTimeout,
+        iden: QueueIdentifier,
+    ) -> Result<EnqueuedJob, NoJobDequeued>;
+
+    fn delete_all(&self, iden: QueueIdentifier) -> RobinResult<()>;
+
+    fn size(&self, iden: QueueIdentifier) -> RobinResult<usize>;
+}
 
 /// The number of times a job has been retried, if ever.
 #[derive(Deserialize, Serialize, Debug, Copy, Clone)]

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -20,19 +20,19 @@ where
     type Config;
 
     /// Create a new queue with the given config.
-    fn new(init: &Self::Config) -> JobQueueResult<Self>;
+    fn new(init: &Self::Config) -> JobQueueResult<(Self, Self)>;
 
     /// Push a job into the queue.
-    fn enqueue(&self, enq_job: EnqueuedJob, iden: QueueIdentifier) -> JobQueueResult<()>;
+    fn enqueue(&self, enq_job: EnqueuedJob) -> JobQueueResult<()>;
 
     /// Pull a job from the queue.
-    fn dequeue(&self, iden: QueueIdentifier) -> Result<EnqueuedJob, NoJobDequeued>;
+    fn dequeue(&self) -> Result<EnqueuedJob, NoJobDequeued>;
 
     /// Delete all jobs from the queue.
-    fn delete_all(&self, iden: QueueIdentifier) -> JobQueueResult<()>;
+    fn delete_all(&self) -> JobQueueResult<()>;
 
     /// Get the number of jobs in the queue.
-    fn size(&self, iden: QueueIdentifier) -> JobQueueResult<usize>;
+    fn size(&self) -> JobQueueResult<usize>;
 }
 
 /// The result type returned by job backends.
@@ -47,7 +47,7 @@ pub trait JobQueueErrorInformation: Debug {
     fn description(&self) -> &str;
 
     /// An optional secondary error message providing more details about the
-    /// problem, if it was provided by the database. Might span multiple lines.
+    /// problem.
     fn details(&self) -> Option<&str> {
         None
     }
@@ -211,14 +211,4 @@ pub enum QueueIdentifier {
     /// If a job from the main queue fails it gets put into the retry queue
     /// and retried later.
     Retry,
-}
-
-impl QueueIdentifier {
-    /// Convert the name to the string used for the Redis key.
-    pub fn redis_queue_name(&self) -> String {
-        match *self {
-            QueueIdentifier::Main => "main".to_string(),
-            QueueIdentifier::Retry => "retry".to_string(),
-        }
-    }
 }

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -11,9 +11,9 @@ pub trait JobQueue
 where
     Self: Sized,
 {
-    type Init;
+    type Config;
 
-    fn new(init: &Self::Init) -> RobinResult<Self>;
+    fn new(init: &Self::Config) -> RobinResult<Self>;
 
     fn enqueue(&self, enq_job: EnqueuedJob, iden: QueueIdentifier) -> RobinResult<()>;
 

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -1,6 +1,10 @@
 /// Contains a queue implementation using Redis.
 pub mod redis_queue;
 
+/// Contains an in-memory queue. This queue stores the jobs in-memory of the running Rust process
+/// and therefore wont work across processes. Normally you'd only use this during testing.
+pub mod memory_queue;
+
 use serde_json;
 use redis;
 use error::*;
@@ -68,6 +72,15 @@ pub struct EnqueuedJob {
 }
 
 impl EnqueuedJob {
+    /// Create a new `EnqueuedJob`
+    pub fn new(name: &str, args: &str, retry_count: RetryCount) -> Self {
+        EnqueuedJob {
+            name: name.to_string(),
+            args: args.to_string(),
+            retry_count: retry_count,
+        }
+    }
+
     /// Get the name
     pub fn name(&self) -> &str {
         &self.name

--- a/robin/src/queue_adapters/redis_queue.rs
+++ b/robin/src/queue_adapters/redis_queue.rs
@@ -1,12 +1,13 @@
 use error::*;
-use redis::{Client, Commands};
 use serde_json;
 use super::{EnqueuedJob, JobQueue, NoJobDequeued, QueueIdentifier};
-use redis;
 use std::fmt;
-use std::default::Default;
 
-/// A wrapper around an actual `redis::Connection`.
+use std::default::Default;
+use redis;
+use redis::{Client, Commands};
+
+/// A queue backend the persists the jobs in Redis.
 pub struct RedisQueue {
     redis: redis::Connection,
     redis_url: String,
@@ -32,9 +33,7 @@ pub struct RedisConfig {
     /// namespace.
     pub namespace: String,
 
-    /// The number of seconds the worker will block while waiting for a new job
-    /// to be enqueued. By default workers will retry after the timeout is hit,
-    /// so you shouldn't need to configure this.
+    /// The number of seconds the worker will block while waiting for a new job to be enqueued.
     pub timeout: usize,
 }
 

--- a/robin/src/queue_adapters/redis_queue.rs
+++ b/robin/src/queue_adapters/redis_queue.rs
@@ -21,14 +21,14 @@ impl RedisQueue {
 
 /// The arguments required to create a new `RedisQueue`
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct RedisQueueInit {
+pub struct RedisConfig {
     pub url: String,
     pub namespace: String,
 }
 
-impl Default for RedisQueueInit {
-    fn default() -> RedisQueueInit {
-        RedisQueueInit {
+impl Default for RedisConfig {
+    fn default() -> RedisConfig {
+        RedisConfig {
             namespace: "robin_".to_string(),
             url: "redis://127.0.0.1/".to_string(),
         }
@@ -36,10 +36,10 @@ impl Default for RedisQueueInit {
 }
 
 impl JobQueue for RedisQueue {
-    type Init = RedisQueueInit;
+    type Init = RedisConfig;
 
     /// Create a new `RedisQueue` using the given config
-    fn new(init: &RedisQueueInit) -> RobinResult<Self> {
+    fn new(init: &RedisConfig) -> RobinResult<Self> {
         let client = Client::open(init.url.as_ref())?;
 
         let con = client.get_connection()?;

--- a/robin/src/queue_adapters/redis_queue.rs
+++ b/robin/src/queue_adapters/redis_queue.rs
@@ -1,9 +1,9 @@
-use serde_json;
 use super::*;
-use std::fmt;
-use std::default::Default;
 use redis;
 use redis::{Client, Commands};
+use serde_json;
+use std::default::Default;
+use std::fmt;
 
 /// A queue backend the persists the jobs in Redis.
 pub struct RedisQueue {

--- a/robin/src/queue_adapters/redis_queue.rs
+++ b/robin/src/queue_adapters/redis_queue.rs
@@ -23,7 +23,13 @@ impl RedisQueue {
 /// The arguments required to create a new `RedisQueue`
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct RedisConfig {
+    /// The URL used to connect to Redis.
+    ///
+    /// Default is "redis://127.0.0.1/"
     pub url: String,
+
+    /// The key that will be prepended all Robin related Redis keys. Effectively working as a
+    /// namespace.
     pub namespace: String,
 
     /// The number of seconds the worker will block while waiting for a new job

--- a/robin/src/queue_adapters/redis_queue.rs
+++ b/robin/src/queue_adapters/redis_queue.rs
@@ -1,11 +1,8 @@
-use error::*;
 use serde_json;
 use super::*;
 use std::fmt;
-use std::error::Error;
 use std::default::Default;
 use redis;
-use redis::RedisError;
 use redis::{Client, Commands};
 
 /// A queue backend the persists the jobs in Redis.
@@ -115,7 +112,7 @@ impl JobQueue for RedisQueue {
     }
 }
 
-impl fmt::Debug for RedisQueue {
+impl Debug for RedisQueue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/robin/src/queue_adapters/redis_queue.rs
+++ b/robin/src/queue_adapters/redis_queue.rs
@@ -36,7 +36,7 @@ impl Default for RedisConfig {
 }
 
 impl JobQueue for RedisQueue {
-    type Init = RedisConfig;
+    type Config = RedisConfig;
 
     /// Create a new `RedisQueue` using the given config
     fn new(init: &RedisConfig) -> RobinResult<Self> {

--- a/robin/src/worker.rs
+++ b/robin/src/worker.rs
@@ -187,6 +187,10 @@ where
         Err(NoJobDequeued::BecauseError(err)) => {
             panic!(format!("Failed to dequeue job with error\n{:?}", err))
         }
+
+        Err(NoJobDequeued::BecauseUnknownJob(name)) => {
+            panic!(format!("Received unknown job from the queue\n{:?}", name.0))
+        }
     }
 }
 

--- a/robin/src/worker.rs
+++ b/robin/src/worker.rs
@@ -1,7 +1,7 @@
 use config::Config;
 use connection::*;
 use job::*;
-use queue_adapters::{DequeueTimeout, JobQueue, NoJobDequeued, QueueIdentifier, RetryCount};
+use queue_adapters::{JobQueue, NoJobDequeued, QueueIdentifier, RetryCount};
 use serde_json;
 use std::sync::mpsc::*;
 use std::thread::{self, JoinHandle};
@@ -164,7 +164,7 @@ fn dequeue_job<Q>(con: &Connection<Q>, iden: QueueIdentifier) -> DequeuedJob<Q>
 where
     Q: JobQueue,
 {
-    con.dequeue_from(iden, DequeueTimeout(con.config().timeout))
+    con.dequeue_from(iden)
 }
 
 #[derive(Debug)]

--- a/robin/src/worker.rs
+++ b/robin/src/worker.rs
@@ -133,7 +133,7 @@ fn worker_loop<Q, T, K>(
     let mut received_perform_jobs_and_die = false;
 
     loop {
-        let job = dequeue_job(&con, queue_iden);
+        let job = con.dequeue_from(queue_iden);
         let output = perform_job(job, &con);
 
         match output {
@@ -159,13 +159,6 @@ fn worker_loop<Q, T, K>(
 }
 
 type DequeuedJob<Q> = Result<(Box<Job<Q> + Send + 'static>, String, RetryCount), NoJobDequeued>;
-
-fn dequeue_job<Q>(con: &Connection<Q>, iden: QueueIdentifier) -> DequeuedJob<Q>
-where
-    Q: JobQueue,
-{
-    con.dequeue_from(iden)
-}
 
 #[derive(Debug)]
 enum PerformJobOutput {

--- a/robin/tests/integration_test.rs
+++ b/robin/tests/integration_test.rs
@@ -5,9 +5,9 @@ extern crate uuid;
 mod test_helpers;
 use test_helpers::*;
 
+use robin::memory_queue::*;
 use robin::prelude::*;
 use robin::redis_queue::*;
-use robin::memory_queue::*;
 
 robin_test!(performing_jobs, || {
     jobs! { TestJob(String) }

--- a/robin/tests/integration_test.rs
+++ b/robin/tests/integration_test.rs
@@ -7,6 +7,7 @@ use test_helpers::*;
 
 use robin::prelude::*;
 use robin::redis_queue::*;
+use robin::memory_queue::*;
 
 robin_test!(performing_jobs, || {
     jobs! { TestJob(String) }
@@ -90,4 +91,36 @@ robin_test!(retrying_jobs, || {
 
     assert_eq!(con.main_queue_size().unwrap(), 0);
     assert_eq!(con.retry_queue_size().unwrap(), 0);
+});
+
+robin_test!(performing_with_in_memory_queue, || {
+    use std::time::Duration;
+
+    jobs! { TestJob(String) }
+
+    impl TestJob {
+        fn perform<Q>(unique_string: String, _con: &Connection<Q>) -> JobResult {
+            write_tmp_test_file(unique_string.clone(), unique_string);
+            Ok(())
+        }
+    }
+
+    let filename = uuid();
+
+    let config = test_config();
+
+    let queue_config = MemoryQueueConfig::default();
+
+    let con: Connection<MemoryQueue> =
+        robin::connection::establish(config, queue_config.clone(), __robin_lookup_job).unwrap();
+
+    TestJob::perform_later(&filename, &con).unwrap();
+
+    robin::worker::spawn_workers::<MemoryQueue, _, _>(
+        &config.clone(),
+        queue_config.clone(),
+        __robin_lookup_job,
+    ).perform_all_jobs_and_die();
+
+    assert_eq!(read_tmp_test_file(filename.clone()).unwrap(), filename);
 });

--- a/robin/tests/integration_test.rs
+++ b/robin/tests/integration_test.rs
@@ -21,14 +21,14 @@ robin_test!(performing_jobs, || {
     let filename = uuid();
 
     let config = test_config();
-    let queue_init = test_redis_init();
-    let con = robin_establish_connection!(RedisQueue, config, queue_init).unwrap();
+    let queue_config = test_redis_init();
+    let con = robin_establish_connection!(RedisQueue, config, queue_config).unwrap();
 
     TestJob::perform_later(&filename, &con).unwrap();
 
     robin::worker::spawn_workers::<RedisQueue, _, _>(
         &config.clone(),
-        queue_init.clone(),
+        queue_config.clone(),
         __robin_lookup_job,
     ).perform_all_jobs_and_die();
 
@@ -45,8 +45,8 @@ robin_test!(main_queue_size_test, || {
     }
 
     let config = test_config();
-    let queue_init = test_redis_init();
-    let con = robin_establish_connection!(RedisQueue, config, queue_init).unwrap();
+    let queue_config = test_redis_init();
+    let con = robin_establish_connection!(RedisQueue, config, queue_config).unwrap();
 
     assert_eq!(con.main_queue_size().unwrap(), 0);
 
@@ -58,7 +58,7 @@ robin_test!(main_queue_size_test, || {
 
     robin::worker::spawn_workers::<RedisQueue, _, _>(
         &config.clone(),
-        queue_init.clone(),
+        queue_config.clone(),
         __robin_lookup_job,
     ).perform_all_jobs_and_die();
 
@@ -75,8 +75,8 @@ robin_test!(retrying_jobs, || {
     }
 
     let config = test_config();
-    let queue_init = test_redis_init();
-    let con = robin_establish_connection!(RedisQueue, config, queue_init).unwrap();
+    let queue_config = test_redis_init();
+    let con = robin_establish_connection!(RedisQueue, config, queue_config).unwrap();
 
     assert_eq!(con.main_queue_size().unwrap(), 0);
 
@@ -84,7 +84,7 @@ robin_test!(retrying_jobs, || {
 
     robin::worker::spawn_workers::<RedisQueue, _, _>(
         &config.clone(),
-        queue_init.clone(),
+        queue_config.clone(),
         __robin_lookup_job,
     ).perform_all_jobs_and_die();
 

--- a/robin/tests/test_helpers/mod.rs
+++ b/robin/tests/test_helpers/mod.rs
@@ -1,4 +1,8 @@
-use std::{error, fmt, io, fs::{self, File}, io::{BufWriter, Write, prelude::*}};
+use std::{error,
+          fmt,
+          fs::{self, File},
+          io,
+          io::{prelude::*, BufWriter, Write}};
 
 use robin::prelude::*;
 use robin::redis_queue::*;

--- a/robin/tests/test_helpers/mod.rs
+++ b/robin/tests/test_helpers/mod.rs
@@ -15,8 +15,8 @@ pub fn test_config() -> Config {
     config
 }
 
-pub fn test_redis_init() -> RedisQueueInit {
-    let mut config = RedisQueueInit::default();
+pub fn test_redis_init() -> RedisConfig {
+    let mut config = RedisConfig::default();
     config.namespace = uuid();
     config
 }

--- a/robin/tests/test_helpers/mod.rs
+++ b/robin/tests/test_helpers/mod.rs
@@ -10,14 +10,13 @@ pub fn setup() {
 pub fn teardown() {}
 
 pub fn test_config() -> Config {
-    let mut config = Config::default();
-    config.timeout = 1;
-    config
+    Config::default()
 }
 
 pub fn test_redis_init() -> RedisConfig {
     let mut config = RedisConfig::default();
     config.namespace = uuid();
+    config.timeout = 1;
     config
 }
 

--- a/robin/tests/test_helpers/mod.rs
+++ b/robin/tests/test_helpers/mod.rs
@@ -1,6 +1,7 @@
 use std::{error, fmt, io, fs::{self, File}, io::{BufWriter, Write, prelude::*}};
 
 use robin::prelude::*;
+use robin::redis_queue::*;
 
 pub fn setup() {
     fs::create_dir("tests/tmp").ok();
@@ -10,10 +11,13 @@ pub fn teardown() {}
 
 pub fn test_config() -> Config {
     let mut config = Config::default();
-
-    config.redis_namespace = uuid();
     config.timeout = 1;
+    config
+}
 
+pub fn test_redis_init() -> RedisQueueInit {
+    let mut config = RedisQueueInit::default();
+    config.namespace = uuid();
     config
 }
 

--- a/typesafe-derive-builder/src/lib.rs
+++ b/typesafe-derive-builder/src/lib.rs
@@ -4,8 +4,8 @@ extern crate quote;
 extern crate rand;
 extern crate syn;
 
-use std::iter::repeat;
 use proc_macro::TokenStream;
+use std::iter::repeat;
 
 #[proc_macro_derive(Builder)]
 pub fn code_gen_builder(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
In the future, I would like to add different kinds of queue backends. I don't think Redis is right for all projects all the time. I would like to give the users the option to choose while making it easy to just use Redis if that is fine for them.

Part of https://github.com/davidpdrsn/robin/issues/52

---

## TODO

- [x] Error handling when users are defining their own queues. `Error` currently has `RedisError`.
- [ ] Read the docs and make sure they still make sense.
- [x] Implement an in-memory queue.
  - [x] Error handling in in-memory queue.
- [x] Change `JobQueue` such that the methods don't take a queue identifier.
- [ ] Make sure change log is up to date.