### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/robin-derives/Cargo.toml
+++ b/robin-derives/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 license = "MIT"
 description = "Custom derives used in the Robin crate"
+edition = "2018"
 
 [dependencies]
 syn = "0.12.14"

--- a/robin/Cargo.toml
+++ b/robin/Cargo.toml
@@ -9,6 +9,7 @@ name = "robin"
 readme = "README.md"
 repository = "https://github.com/davidpdrsn/robin.git"
 version = "0.3.0"
+edition = "2018"
 
 [dependencies]
 serde = "1.0"

--- a/robin/src/connection.rs
+++ b/robin/src/connection.rs
@@ -1,7 +1,7 @@
-use config::Config;
-use error::*;
-use job::*;
-use queue_adapters::{redis_queue::RedisQueue, EnqueuedJob, JobQueue, NoJobDequeued,
+use crate::config::Config;
+use crate::error::*;
+use crate::job::*;
+use crate::queue_adapters::{redis_queue::RedisQueue, EnqueuedJob, JobQueue, NoJobDequeued,
                      QueueIdentifier, RetryCount};
 
 /// Create a new connection.

--- a/robin/src/error.rs
+++ b/robin/src/error.rs
@@ -1,4 +1,4 @@
-use queue_adapters::{JobQueueError, JobQueueErrorInformation};
+use crate::queue_adapters::{JobQueueError, JobQueueErrorInformation};
 use serde_json;
 use std::{error, fmt};
 

--- a/robin/src/job.rs
+++ b/robin/src/job.rs
@@ -1,8 +1,8 @@
 extern crate serde_json;
 
-use connection::Connection;
-use error::{Error, RobinResult};
-use queue_adapters::{JobQueue, QueueIdentifier, RetryCount};
+use crate::connection::Connection;
+use crate::error::{Error, RobinResult};
+use crate::queue_adapters::{JobQueue, QueueIdentifier, RetryCount};
 use serde::{Deserialize, Serialize};
 use std;
 

--- a/robin/src/lib.rs
+++ b/robin/src/lib.rs
@@ -147,21 +147,21 @@ pub mod prelude {
     //! Reexports the most commonly used types and traits from the other modules.
     //! As long as you're doing standard things this is the only `use` you'll need.
 
-    pub use config::Config;
-    pub use connection::{establish, Connection, LookupJob};
-    pub use error::RobinResult;
-    pub use job::{Args, Job, JobName, JobResult, PerformJob};
-    pub use queue_adapters::JobQueue;
-    pub use worker::{boot, spawn_workers};
+    pub use crate::config::Config;
+    pub use crate::connection::{establish, Connection, LookupJob};
+    pub use crate::error::RobinResult;
+    pub use crate::job::{Args, Job, JobName, JobResult, PerformJob};
+    pub use crate::queue_adapters::JobQueue;
+    pub use crate::worker::{boot, spawn_workers};
 }
 
 /// Contains the types you'll need if you wish to use Redis as your backend.
 pub mod redis_queue {
-    pub use queue_adapters::redis_queue::{RedisConfig, RedisQueue};
+    pub use crate::queue_adapters::redis_queue::{RedisConfig, RedisQueue};
 }
 
 /// Contains the types you'll need if you wish to use Robins in-memory queue. Usually only used for
 /// testing.
 pub mod memory_queue {
-    pub use queue_adapters::memory_queue::{MemoryQueue, MemoryQueueConfig};
+    pub use crate::queue_adapters::memory_queue::{MemoryQueue, MemoryQueueConfig};
 }

--- a/robin/src/queue_adapters/memory_queue.rs
+++ b/robin/src/queue_adapters/memory_queue.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 use super::*;
-use error::*;
+use crate::error::*;
 use std::default::Default;
 use std::{sync::{mpsc::{channel, Receiver, SendError, Sender},
                  Arc,

--- a/robin/src/queue_adapters/mod.rs
+++ b/robin/src/queue_adapters/mod.rs
@@ -5,8 +5,8 @@ pub mod redis_queue;
 /// and therefore wont work across processes. Normally you'd only use this during testing.
 pub mod memory_queue;
 
-use config::Config;
-use job::JobName;
+use crate::config::Config;
+use crate::job::JobName;
 use std::marker::Sized;
 use std::{error,
           fmt::{self, Debug}};

--- a/robin/src/worker.rs
+++ b/robin/src/worker.rs
@@ -1,7 +1,7 @@
-use config::Config;
-use connection::*;
-use job::*;
-use queue_adapters::{JobQueue, NoJobDequeued, QueueIdentifier, RetryCount};
+use crate::config::Config;
+use crate::connection::*;
+use crate::job::*;
+use crate::queue_adapters::{JobQueue, NoJobDequeued, QueueIdentifier, RetryCount};
 use serde_json;
 use std::sync::mpsc::*;
 use std::thread::{self, JoinHandle};

--- a/robin/tests/integration_test.rs
+++ b/robin/tests/integration_test.rs
@@ -3,7 +3,7 @@ extern crate robin;
 extern crate uuid;
 
 mod test_helpers;
-use test_helpers::*;
+use crate::test_helpers::*;
 
 use robin::memory_queue::*;
 use robin::prelude::*;
@@ -94,7 +94,7 @@ robin_test!(retrying_jobs, || {
 });
 
 robin_test!(performing_with_in_memory_queue, || {
-    use std::time::Duration;
+    
 
     jobs! { TestJob(String) }
 

--- a/typesafe-derive-builder/Cargo.toml
+++ b/typesafe-derive-builder/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 description = "Derive builder macro"
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 syn = "0.11.11"


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'